### PR TITLE
:arrow_up: Update for Elm 0.16

### DIFF
--- a/TapTest.elm
+++ b/TapTest.elm
@@ -43,6 +43,7 @@ update action model =
   case action of
     Increment -> model + 1
     Decrement -> model - 1
+    NoOp      -> model
 
 actions = Signal.mailbox NoOp
     

--- a/elm-package.json
+++ b/elm-package.json
@@ -11,9 +11,9 @@
         "MouseTouch.Eval"
     ],
     "dependencies": {
-        "elm-lang/core": "2.1.0 <= v < 3.0.0",
-        "evancz/elm-html": "4.0.0 <= v < 5.0.0"
+        "elm-lang/core": "3.0.0 <= v < 4.0.0",
+        "evancz/elm-html": "4.0.2 <= v < 5.0.0"
     },
     "native-modules" : true,
-    "elm-version": "0.15.1 <= v < 0.16.0"
+    "elm-version": "0.16.0 <= v < 0.17.0"
 }


### PR DESCRIPTION
Updated the dependencies and follow the new syntax.
According to https://github.com/elm-lang/elm-platform/blob/master/upgrade-docs/0.16.md

I use this forked repository until https://github.com/Pisys/elm-mousetouch/pull/2 gets merged.
And I might add more changes to this repository.
So maybe keeping this repository's master up-to-date is better.
That's why I merge this branch.
